### PR TITLE
to use distance as the driver versus region

### DIFF
--- a/stagings.yml
+++ b/stagings.yml
@@ -1,84 +1,60 @@
-Providence:
-  HP-6Z6:
-    group: Deep Space Alliance <ADS>
-  JEIV-E:
-    group: The Rogue Consortium <T.R.C>
-  S9X-AX:
-    group: LinkNet <LINE>
-  XHQ-7V:
-    group: Curatores Veritatis Alliance <CVA>
-Catch:
-  ERVK-P:
-    group: Red Alliance <RED>
-  EX6-AO:
-    group: Dracarys. <D.C>
-  HP-64T:
-    group: Dracarys. <D.C>
-Tenerifis:
-  Q5KZ-W:
-    group: Paper Numbers <553M>
-  77S8-E:
-    group: Gentlemen's.Club <GCLUB>
-Scalding Pass:  
-  8CN-CH:
-    group: Naval Defense Alliance <NAVY>
-Querious:
-  P-ZMZV:
-    group: Dracarys. <D.C>
-  OGY-6D:
-    group: Brave Collective <BRAVE>
-Wicked Creek:
-  SR-4EK:
-    group: Triumvirate. <TRI>
-Deteroid:
-  77S8-E:
-    group: Gentlemen's.Club <GCLUB>
-Esoteria:
-  D-PNP9:
-    group: Shadow Ultimatum <SHADO>
-Etherium Reach:
-  F9-FUV:
-    group: Solyaris Chtonium <SLYCCE>
-Pure Blind:
-  F-NMX6:
-    group: Synergy of Steel <SYN>
-Branch:
-  BKG-Q2:
-    group: Fraternity. <FRT> / Siberian Squads <SB-SQ> / Azure Citizen <AZURE>
-Delve:
-  1DQ1-A:
-    group: Goonswarm Federation <CONDI>
-Paragon Soul:
-  O4T-Z5:
-    group:  Sigma Grindset <5IGMA>
-Vale of the Silent:
-  4-HWWF:
-    group: Fraternity. <FRT>
-Curse:
-  D87E-A:
-    group: UA Fleets <UAFL>
-  G-0Q86:
-    group: DECOY <DECOY>
-Feythabolis:
-  RIT-A7:
-    group: ZERG REBORN <ZERG>
-  PO-3QF:
-    group: HOLD MY PROBS <PROB>
-Fountain:
-  B17O-R:
-    group: The Initiative. <INIT.>
-Omist:
-  AXDX-F:
-    group: Mohist Alliance <MO.>
-Perrigen Falls:
-  MJ-5F9:
-    group: Pandemic Horde <REKTD>
-Stain:
-  4GQ-XQ:
-    group: Ferrata Victrix <FERRA> / Legion of xXDEATHXx <X.I.X.>
-Syndicate:
-  PC9-AY:
-    group: Ivy League <IVY> / United Federation of Conifers <.UFC.>
-The Kalevala Expanse:
-  C3J0-O:
-    group: Pandemic Horse <REKTD>
+HP-6Z6:
+  group: Deep Space Alliance
+JEIV-E:
+  group: The Rogue Consortium
+S9X-AX:
+  group: LinkNet
+XHQ-7V:
+  group: Curatores Veritatis Alliance
+ERVK-P:
+  group: Red Alliance
+EX6-AO:
+  group: Dracarys.
+HP-64T:
+  group: Dracarys.
+Q5KZ-W:
+  group: Paper Numbers
+77S8-E:
+  group: Gentlemen's.Club
+8CN-CH:
+  group: Naval Defense Alliance
+P-ZMZV:
+  group: Dracarys.
+OGY-6D:
+  group: Brave Collective
+SR-4EK:
+  group: Triumvirate.
+D-PNP9:
+  group: Shadow Ultimatum
+F9-FUV:
+  group: Solyaris Chtonium
+F-NMX6:
+  group: Synergy of Steel
+BKG-Q2:
+  group: Fraternity. / Siberian Squads / Azure Citizen
+1DQ1-A:
+  group: Goonswarm Federation
+O4T-Z5:
+  group:  Sigma Grindset
+4-HWWF:
+  group: Fraternity.
+D87E-A:
+  group: UA Fleets
+G-0Q86:
+  group: DECOY
+RIT-A7:
+  group: ZERG REBORN
+PO-3QW:
+  group: HOLD MY PROBS
+B17O-R:
+  group: The Initiative.
+AXDX-F:
+  group: Mohist Alliance
+MJ-5F9:
+  group: Pandemic Horde
+4GQ-XQ:
+  group: Ferrata Victrix / Legion of xXDEATHXx
+PC9-AY:
+  group: Ivy League / United Federation of Conifers
+C3J0-O:
+  group: Pandemic Horse


### PR DESCRIPTION
# Summary

Rework code and stagings.yaml to be distance based. This generally simplifies and retains the same number of network calls.

## Example updated message

```
8 jumps from The Rogue Consortium in JEIV-E using Soosat!
10 jumps from Curatores Veritatis Alliance in XHQ-7V using Judra!
7 jumps from Curatores Veritatis Alliance in XHQ-7V using Soosat!
5 jumps from Fraternity. in 4-HWWF using P3EN-E!
8 jumps from DECOY in G-0Q86 using N5Y-4N!
10 jumps from Pandemic Horse in C3J0-O using BZ-BCK!
```