### PR TITLE
add recipe install-githooks; add to dev

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+make lint
+if [[ $? == 0 ]]; then
+    printf "good Commit"
+else
+    printf "Lint Issues! Please resolve before commiting.\n"
+    printf "commit-msg hook failed (add --no-verify to bypass)\n"
+    exit 1
+fi

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ $(VENV)::$(CURDIR)/requirements.txt
 
 dev:
 	$(MAKE) $(VENV)
+	$(MAKE) install-githooks
 
 
 lint:
@@ -19,6 +20,10 @@ lint:
 	$(CURDIR)/.venv/bin/flake8
 	$(CURDIR)/.venv/bin/bandit -lll -r $(CURDIR)/main.py
 	$(CURDIR)/.venv/bin/brunette --check .
+
+
+install-githooks:
+	git config --local core.hooksPath .githooks
 
 
 clean:


### PR DESCRIPTION
# Summary

- Create `install-githooks` recipe to set `pre-commit` `githook`
- Add `install-githooks` recipe to `dev` recipe


# Notes
- A permission error is raised if  the `pre-commit` script doesn't call out the interpreter... I have not had that issue in 6 years of using `githooks`. The required changes seems to make sense so I don't see it as a risk but strange.
